### PR TITLE
feat: extension spawned hanging process auto clean up

### DIFF
--- a/apps/desktop/components/ExtTemplate/FormView.vue
+++ b/apps/desktop/components/ExtTemplate/FormView.vue
@@ -13,6 +13,10 @@ const props = defineProps<{
 	fieldConfig: Record<string, any>
 }>()
 
+const emit = defineEmits<{
+	(e: "goBack"): void
+}>()
+
 onKeyStroke("Escape", () => {
 	if (document.activeElement?.nodeName === "INPUT") {
 		const inputEle = document.activeElement as HTMLInputElement
@@ -32,6 +36,7 @@ function onSubmit(data: Record<string, any>) {
 }
 
 function goBack() {
+	emit('goBack')
 	props.workerAPI.onBeforeGoBack()
 	navigateTo(localePath("/"))
 }

--- a/apps/desktop/components/ExtTemplate/ListView.vue
+++ b/apps/desktop/components/ExtTemplate/ListView.vue
@@ -35,6 +35,10 @@ useListenToWindowFocus(() => {
 	getWorkerExtInputEle()?.focus()
 })
 
+const emit = defineEmits<{
+	(e: "goBack"): void
+}>()
+
 const props = defineProps<{
 	modelValue: ListSchema.List
 	workerAPI: Remote<WorkerExtension>
@@ -151,6 +155,7 @@ watch(highlightedItemValue, (newVal, oldVal) => {
 })
 
 function goBack() {
+	emit('goBack')
 	props.workerAPI.onBeforeGoBack()
 	if (appWin.label !== "main") {
 		return appWin.close()

--- a/apps/desktop/layouts/default.vue
+++ b/apps/desktop/layouts/default.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useGoToSettingShortcuts } from "@/composables/useShortcuts"
 import { useTestDB } from "@/lib/dev/exp"
+import { listenToRecordExtensionProcessEvent } from "@kksh/api/events"
 import { Toaster } from "@kksh/vue/sonner"
 import { Toaster as Toaster2 } from "@kksh/vue/toast"
 import { TooltipProvider } from "@kksh/vue/tooltip"
@@ -11,6 +12,7 @@ import { useRegisterAppShortcuts } from "~/lib/utils/hotkey"
 import { initStores } from "~/lib/utils/stores"
 import { listenToRefreshConfig } from "~/lib/utils/tauri-events"
 import { useAppConfigStore } from "~/stores/appConfig"
+import { useWindowExtMapStore } from "~/stores/windowExtMap"
 import { fixPathEnv } from "tauri-plugin-shellx-api"
 
 const appConfig = useAppConfigStore()
@@ -28,6 +30,17 @@ unlistenRefreshConfig = await listenToRefreshConfig(async () => {
 	initStores()
 	// useRegisterAppShortcuts()
 })
+
+const windowExtMapStore = useWindowExtMapStore()
+if (appWindow.label === "main") {
+	let unlistenRecordExtensionProcessEvent: UnlistenFn = await listenToRecordExtensionProcessEvent(
+		async (event) => {
+			console.log("record extension process event", event)
+			windowExtMapStore.registerProcess(event.payload.windowLabel, event.payload.pid)
+			console.log(windowExtMapStore.windowExtMap)
+		}
+	)
+}
 onMounted(async () => {
 	if (!isMainWindow) {
 		return

--- a/apps/desktop/pages/index.vue
+++ b/apps/desktop/pages/index.vue
@@ -38,6 +38,7 @@ const appConfig = useAppConfigStore()
 await appConfig.init()
 const lastTimeStore = useLastTimeStore()
 const quicklinkLoader = useQuicklinkLoader()
+const windowExtMapStore = useWindowExtMapStore()
 await lastTimeStore.init()
 const extLoaders = ref([
 	devExtStore,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -68,6 +68,9 @@ fn main() {
         })
         .register_uri_scheme_protocol("ext", |app, request| {
             let app_handle = app.app_handle();
+            // app_handle.
+            let win_label = app.webview_label();
+            // let window_ext_map = app_handle.state::<tauri_plugin_jarvis::stores::window_ext_map::WindowExtMap>();
             let app_state = app_handle.state::<tauri_plugin_jarvis::model::app_state::AppState>();
             let extension_path = app_state.extension_path.lock().unwrap().clone();
             tauri_file_server(app_handle, request, extension_path)

--- a/apps/desktop/stores/windowExtMap.ts
+++ b/apps/desktop/stores/windowExtMap.ts
@@ -1,0 +1,80 @@
+import { getExtLabelMap, registerExtensionSpawnedProcess } from "@kksh/api/commands"
+import { error } from "@tauri-apps/plugin-log"
+import { defineStore } from "pinia"
+import { Child } from "tauri-plugin-shellx-api"
+
+export const useWindowExtMapStore = defineStore("window-ext-map", () => {
+	const windowExtMap = ref<
+		Record<
+			string,
+			{
+				windowLabel: string
+				extPath: string
+				pids: number[]
+			}
+		>
+	>({})
+
+	function killProcesses(pids: number[]) {
+		return Promise.all(
+			pids.map((pid) => {
+				return new Child(pid).kill().catch((err) => {
+					error(`Failed to kill process ${pid}, ${err}`)
+					console.error(`Failed to kill process ${pid}`, err)
+				})
+			})
+		)
+	}
+
+	function registerExtensionWithWindow(windowLabel: string, extPath: string) {
+		if (windowExtMap.value[windowLabel]) {
+			killProcesses(windowExtMap.value[windowLabel].pids)
+			delete windowExtMap.value[windowLabel]
+		}
+		if (!windowExtMap.value[windowLabel]) {
+			console.log("registerExtensionWithWindow", windowLabel, extPath)
+			windowExtMap.value[windowLabel] = {
+				windowLabel,
+				extPath,
+				pids: []
+			}
+		}
+	}
+
+	async function unregisterExtensionFromWindow(windowLabel: string) {
+		console.log("unregisterExtensionFromWindow", windowLabel)
+		if (!windowExtMap.value[windowLabel]) {
+			console.warn(`Window ${windowLabel} does not have an extension registered`)
+		} else {
+			const extLabelMap = await getExtLabelMap()
+			Object.entries(extLabelMap).forEach(([label, ext]) => {
+				if (label === windowLabel) {
+					killProcesses(ext.processes)
+				}
+			})
+			// killProcesses(windowExtMap.value[windowLabel].pids)
+			// 	.then(() => {
+			// 		delete windowExtMap.value[windowLabel]
+			// 	})
+			// 	.catch((err) => {
+			// 		error(`Failed to unregister extension from window ${windowLabel}, ${err}`)
+			// 		console.error(`Failed to unregister extension from window ${windowLabel}`, err)
+			// 	})
+		}
+	}
+
+	function registerProcess(windowLabel: string, pid: number) {
+		registerExtensionSpawnedProcess(windowLabel, pid)
+		if (!windowExtMap.value[windowLabel]) {
+			throw new Error(`Window ${windowLabel} does not have an extension registered`)
+		}
+		windowExtMap.value[windowLabel].pids.push(pid)
+	}
+
+	return {
+		windowExtMap,
+		registerProcess,
+		registerExtensionWithWindow,
+		unregisterExtensionFromWindow
+	}
+})

--- a/extensions/demo-worker-template-ext/package.json
+++ b/extensions/demo-worker-template-ext/package.json
@@ -10,6 +10,7 @@
     "identifier": "demo-worker-template-ext",
     "permissions": [
       "fetch:all",
+      "shell:kill",
       {
         "permission": "shell:deno:execute",
         "allow": [

--- a/packages/api/jsr.json
+++ b/packages/api/jsr.json
@@ -12,7 +12,8 @@
 		"./runtime/deno": "./src/runtime/deno.ts",
 		"./commands": "./src/commands/index.ts",
 		"./permissions": "./src/permissions/index.ts",
-		"./dev": "./src/dev/index.ts"
+		"./dev": "./src/dev/index.ts",
+		"./events": "./src/events.ts"
 	},
 	"imports": {
 		"@hk/comlink-stdio": "jsr:@hk/comlink-stdio@^0.1.6"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
 		"./commands": "./src/commands/index.ts",
 		"./permissions": "./src/permissions/index.ts",
 		"./dev": "./src/dev/index.ts",
+		"./events": "./src/events.ts",
 		"./package.json": "./package.json"
 	},
 	"license": "MIT",

--- a/packages/api/src/commands/extension.ts
+++ b/packages/api/src/commands/extension.ts
@@ -10,12 +10,19 @@ export function isWindowLabelRegistered(label: string): Promise<boolean> {
  * @param extensionPath
  * @returns Window Label
  */
-export function registerExtensionWindow(extensionPath: string): Promise<string> {
-	return invoke(generateJarvisPluginCommand("register_extension_window"), { extensionPath })
+export function registerExtensionWindow(extensionPath: string, windowLabel?: string): Promise<string> {
+	return invoke(generateJarvisPluginCommand("register_extension_window"), { extensionPath, windowLabel })
 }
 
 export function unregisterExtensionWindow(label: string): Promise<void> {
 	return invoke(generateJarvisPluginCommand("unregister_extension_window"), { label })
+}
+
+export function registerExtensionSpawnedProcess(windowLabel: string, pid: number): Promise<void> {
+	return invoke(generateJarvisPluginCommand("register_extension_spawned_process"), {
+		windowLabel,
+		pid
+	})
 }
 
 export function getExtLabelMap(): Promise<ExtensionLabelMap> {

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -8,3 +8,4 @@ export enum KUNKUN_EXT_IDENTIFIER {
 
 export const KUNKUN_DESKTOP_APP_SERVER_PORTS = [1566, 1567, 1568, 9559, 9560, 9561]
 export const DESKTOP_SERVICE_NAME = "Kunkun"
+

--- a/packages/api/src/events.ts
+++ b/packages/api/src/events.ts
@@ -1,0 +1,22 @@
+import { listen, type EventCallback, type UnlistenFn } from "@tauri-apps/api/event"
+
+/* ------------------------------- Event Names ------------------------------ */
+export const RECORD_EXTENSION_PROCESS_EVENT = "record-extension-process"
+export interface IRecordExtensionProcessEvent {
+	windowLabel: string
+	pid: number
+}
+
+/**
+ * listen to RECORD_EXTENSION_PROCESS_EVENT
+ * This event is emitted when an extension spawns a process. Processes won't be cleaned up automatically
+ * Extensions should clean up the processes when extension quits, but there is no way to guarantee this.
+ * So we need to record the processes spawned from extensions and clean up the processes when extension quits.
+ * @param callback 
+ * @returns 
+ */
+export function listenToRecordExtensionProcessEvent(
+	callback: EventCallback<IRecordExtensionProcessEvent>
+): Promise<UnlistenFn> {
+	return listen<IRecordExtensionProcessEvent>(RECORD_EXTENSION_PROCESS_EVENT, callback)
+}

--- a/packages/api/src/models/extension.ts
+++ b/packages/api/src/models/extension.ts
@@ -20,7 +20,8 @@ import { Icon } from "./icon"
 export const ExtensionLabelMap = record(
 	string("Window label"),
 	object({
-		path: string("Path to the extension")
+		path: string("Path to the extension"),
+		processes: array(number())
 	})
 )
 export type ExtensionLabelMap = InferOutput<typeof ExtensionLabelMap>

--- a/packages/api/src/ui/iframe/index.ts
+++ b/packages/api/src/ui/iframe/index.ts
@@ -91,3 +91,4 @@ export const {
 	open,
 	app
 } = _api
+export { Child, RPCChannel } from "../api/shell"

--- a/packages/api/src/ui/server/server-types.ts
+++ b/packages/api/src/ui/server/server-types.ts
@@ -22,6 +22,7 @@ export type IShellServer = IShellServer1 & {
 		args: string[],
 		cb: (evt: CommandEvent<O>) => void
 	): Promise<number>
+	recordSpawnedProcess(pid: number): Promise<void>
 }
 
 // This will be implemented in the @kksh/api package

--- a/packages/api/src/ui/server/shell.ts
+++ b/packages/api/src/ui/server/shell.ts
@@ -1,10 +1,13 @@
 import { Channel, invoke } from "@tauri-apps/api/core"
+import { emitTo } from "@tauri-apps/api/event"
+import { getCurrentWindow } from "@tauri-apps/api/window"
 import {
 	type ChildProcess,
 	type CommandEvent,
 	type InternalSpawnOptions,
 	type IOPayload
 } from "tauri-plugin-shellx-api"
+import { RECORD_EXTENSION_PROCESS_EVENT, type IRecordExtensionProcessEvent } from "../../events"
 import { ShellPermissionMap } from "../../permissions/permission-map"
 import { type ShellPermission, type ShellPermissionScoped } from "../../permissions/schema"
 import { verifyScopedPermission } from "../../utils/path"
@@ -203,6 +206,17 @@ export function constructShellApi(
 	}
 
 	return {
+		async recordSpawnedProcess(pid: number): Promise<void> {
+			// get window label
+			const curWin = await getCurrentWindow()
+			console.log("recordSpawnedProcess", pid, curWin.label)
+			await emitTo("main", RECORD_EXTENSION_PROCESS_EVENT, {
+				windowLabel: curWin.label,
+				pid
+			} satisfies IRecordExtensionProcessEvent)
+			// TODO: record process in a store
+			return Promise.resolve()
+		},
 		async denoExecute(
 			scriptPath: string,
 			config: DenoRunConfig,

--- a/packages/api/src/ui/worker/index.ts
+++ b/packages/api/src/ui/worker/index.ts
@@ -94,6 +94,7 @@ export const {
 	app,
 	workerUi: ui
 } = _api
+export { Child, RPCChannel } from "../api/shell"
 
 /* -------------------------------------------------------------------------- */
 /*                             UI Component Schema                            */

--- a/packages/api/src/version.ts
+++ b/packages/api/src/version.ts
@@ -8,7 +8,7 @@ export const breakingChangesVersionCheckpoints = [
 const checkpointVersions = breakingChangesVersionCheckpoints.map((c) => c.version)
 const sortedCheckpointVersions = sort(checkpointVersions)
 
-export const version = "0.0.12-beta.5"
+export const version = "0.0.16"
 
 export function isVersionBetween(v: string, start: string, end: string) {
 	const vCleaned = clean(v)

--- a/packages/tauri-plugin-jarvis/build.rs
+++ b/packages/tauri-plugin-jarvis/build.rs
@@ -59,6 +59,7 @@ const COMMANDS: &[&str] = &[
     "get_default_extensions_storage_dir",
     "is_window_label_registered",
     "register_extension_window",
+    "register_extension_spawned_process",
     "unregister_extension_window",
     "get_ext_label_map",
     // "ext_store_wrapper_set",

--- a/packages/tauri-plugin-jarvis/permissions/all.toml
+++ b/packages/tauri-plugin-jarvis/permissions/all.toml
@@ -60,6 +60,7 @@ commands.allow = [
     "is_window_label_registered",
     "register_extension_window",
     "unregister_extension_window",
+    "register_extension_spawned_process",
     "get_ext_label_map",
     "get_frontmost_app",
     # Database

--- a/packages/tauri-plugin-jarvis/permissions/autogenerated/commands/register_extension_spawned_process.toml
+++ b/packages/tauri-plugin-jarvis/permissions/autogenerated/commands/register_extension_spawned_process.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-register-extension-spawned-process"
+description = "Enables the register_extension_spawned_process command without any pre-configured scope."
+commands.allow = ["register_extension_spawned_process"]
+
+[[permission]]
+identifier = "deny-register-extension-spawned-process"
+description = "Denies the register_extension_spawned_process command without any pre-configured scope."
+commands.deny = ["register_extension_spawned_process"]

--- a/packages/tauri-plugin-jarvis/permissions/autogenerated/reference.md
+++ b/packages/tauri-plugin-jarvis/permissions/autogenerated/reference.md
@@ -1454,6 +1454,32 @@ Denies the refresh_applications_list_in_bg command without any pre-configured sc
 <tr>
 <td>
 
+`jarvis:allow-register-extension-spawned-process`
+
+</td>
+<td>
+
+Enables the register_extension_spawned_process command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`jarvis:deny-register-extension-spawned-process`
+
+</td>
+<td>
+
+Denies the register_extension_spawned_process command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `jarvis:allow-register-extension-window`
 
 </td>

--- a/packages/tauri-plugin-jarvis/permissions/schemas/schema.json
+++ b/packages/tauri-plugin-jarvis/permissions/schemas/schema.json
@@ -850,6 +850,16 @@
           "const": "deny-refresh-applications-list-in-bg"
         },
         {
+          "description": "Enables the register_extension_spawned_process command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-register-extension-spawned-process"
+        },
+        {
+          "description": "Denies the register_extension_spawned_process command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-register-extension-spawned-process"
+        },
+        {
           "description": "Enables the register_extension_window command without any pre-configured scope.",
           "type": "string",
           "const": "allow-register-extension-window"

--- a/packages/tauri-plugin-jarvis/src/lib.rs
+++ b/packages/tauri-plugin-jarvis/src/lib.rs
@@ -119,6 +119,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::extension::is_window_label_registered,
             commands::extension::register_extension_window,
             commands::extension::unregister_extension_window,
+            commands::extension::register_extension_spawned_process,
             commands::extension::get_ext_label_map,
             /* ---------------------- extension storage API wrapper --------------------- */
             // commands::storage::ext_store_wrapper_set,

--- a/packages/tauri-plugin-jarvis/src/model/extension.rs
+++ b/packages/tauri-plugin-jarvis/src/model/extension.rs
@@ -5,6 +5,6 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Extension {
     pub path: PathBuf,
-    pub identifier: String,
-    pub permissions: Vec<Permissions>,
+    pub processes: Vec<u32>,
+    // pub identifier: String,
 }


### PR DESCRIPTION
We store pid of process spawned by extensions, mapped with window label. If a process is  still running when an extension quit, we kill all pid's stored.