### PR TITLE
fix: Improve UX by disabling placeholder text selection on CommandInput component

### DIFF
--- a/apps/desktop/components/cmd-palette/CommandInput.vue
+++ b/apps/desktop/components/cmd-palette/CommandInput.vue
@@ -38,7 +38,7 @@ const emit = defineEmits<{
 			auto-focus
 			:class="
 				cn(
-					'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
+					'placeholder:text-muted-foreground placeholder:select-none flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
 					props.class
 				)
 			"


### PR DESCRIPTION
Hi @HuakunShen and thank you for this amazing app!

I added a small fix to the input css to disable the selection of the placeholder text.

I havent been able to test it as I can't start the project on my local, but that should fix it.

![image](https://github.com/user-attachments/assets/4a1102b9-d543-4d5b-a7ea-8c18a024b932)

BTW. I worked in something similar to this project here (@rokiiapp) Its a port of @cerebroapp to tauri. I am not currently maintaining it, but maybe I can do a rework of some of the extensions to make them work with kunkun.

I'll investigate the extensions API and maybe I open some PRs in the extensions repo.