### PR TITLE
bun downgrade to fix windows build

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -165,7 +165,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.33
+          bun-version: 1.1.27
       - name: Init Environment Variables
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/ci-schema-upload.yml
+++ b/.github/workflows/ci-schema-upload.yml
@@ -30,11 +30,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
-      - name: Install D2 For Docs
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.10
+          bun-version: 1.1.33
       - name: Init Environment Variables
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       #   run: curl -fsSL https://d2lang.com/install.sh | sh -s --
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.33
+          bun-version: 1.1.27
       - name: Init Environment Variables
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/desktop-publish-ci.yml
+++ b/.github/workflows/desktop-publish-ci.yml
@@ -83,7 +83,7 @@ jobs:
           workspaces: "./apps/desktop/src-tauri -> target"
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.33
+          bun-version: 1.1.27
       - name: Init Environment Variables
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/apps/create-kunkun/__tests__/create-template.test.ts
+++ b/apps/create-kunkun/__tests__/create-template.test.ts
@@ -23,8 +23,8 @@ await Promise.all(
 		await $`node ${indexjsPath} --outdir ${testDir} --name ${folderName} --template ${templateName}`
 		const templateDir = path.join(testDir, folderName)
 		await $`rm -rf node_modules`.cwd(templateDir).text() // this doesn't work within bun test
-		await $`npm install`.cwd(templateDir).text() // this doesn't work within bun test
-		await $`npm run build`.cwd(templateDir).text()
+		await $`pnpm install`.cwd(templateDir).text() // this doesn't work within bun test
+		await $`pnpm run build`.cwd(templateDir).text()
 	})
 )
 

--- a/apps/create-kunkun/build.ts
+++ b/apps/create-kunkun/build.ts
@@ -63,7 +63,7 @@ for (const p of fs.readdirSync(tmpDistTemplatesPath)) {
 for (const p of fs.readdirSync(tmpDistTemplatesPath)) {
 	const src = path.join(tmpDistTemplatesPath, p)
 	// skip if src is not a directory
-	if (!fs.lstatSync(src).isDirectory()) {
+	if (!fs.statSync(src).isDirectory()) {
 		continue
 	}
 	const dest = path.join(distTemplatesPath, `${p}.tgz`)


### PR DESCRIPTION
Bun 1.1.33 had problems building ts to js on Windows when dependencies are installed with pnpm. 
Had to downgrade to 1.1.27, seems to work.