### PR TITLE
fix: implemented file server workaround for custom UI commands on Windows

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -113,8 +113,12 @@ pub fn run() {
                 Some(ext) => {
                     // let app_state = app_handle.state::<tauri_plugin_jarvis::model::app_state::AppState>();
                     // let extension_path = app_state.extension_path.lock().unwrap().clone();
-                    // tauri_file_server(app_handle, request, extension_path)
-                    tauri_file_server(app_handle, request, ext.path.clone(), ext.dist.clone())
+                    tauri_file_server(
+                        app_handle,
+                        request,
+                        ext.info.path.clone(),
+                        ext.info.dist.clone(),
+                    )
                 }
                 None => tauri::http::Response::builder()
                     .status(tauri::http::StatusCode::NOT_FOUND)

--- a/apps/desktop/src/routes/+page.svelte
+++ b/apps/desktop/src/routes/+page.svelte
@@ -24,7 +24,7 @@
 	import { cn, commandScore } from "@kksh/ui/utils"
 	import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow"
 	import { exit } from "@tauri-apps/plugin-process"
-	import { CircleXIcon, EllipsisVerticalIcon, RefreshCcwIcon } from "lucide-svelte"
+	import { ArrowBigUpIcon, CircleXIcon, EllipsisVerticalIcon, RefreshCcwIcon } from "lucide-svelte"
 
 	let inputEle: HTMLInputElement | null = null
 	function onKeyDown(event: KeyboardEvent) {
@@ -100,7 +100,6 @@
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content class="w-80">
 					<DropdownMenu.Group>
-						<DropdownMenu.Separator />
 						<DropdownMenu.Item onclick={() => exit()}>
 							<CircleXIcon class="h-4 w-4 text-red-500" />
 							Quit
@@ -116,12 +115,12 @@
 						<DropdownMenu.Item onclick={toggleDevTools}>
 							<Icon icon="mingcute:code-fill" class="mr-2 h-5 w-5 text-green-500" />
 							Toggle Devtools
-							<DropdownMenu.Shortcut>⌃+Shift+I</DropdownMenu.Shortcut>
+							<DropdownMenu.Shortcut><span class="flex items-center">⌃+<ArrowBigUpIcon class="w-4 h-4" />+I</span></DropdownMenu.Shortcut>
 						</DropdownMenu.Item>
 						<DropdownMenu.Item onclick={() => location.reload()}>
 							<RefreshCcwIcon class="mr-2 h-4 w-4 text-green-500" />
 							Reload Window
-							<DropdownMenu.Shortcut>⌃+Shift+R</DropdownMenu.Shortcut>
+							<DropdownMenu.Shortcut><span class="flex items-center">⌃+<ArrowBigUpIcon class="w-4 h-4" />+R</span></DropdownMenu.Shortcut>
 						</DropdownMenu.Item>
 						<DropdownMenu.Item
 							onclick={() => {

--- a/apps/desktop/src/routes/extension/ui-iframe/+page.svelte
+++ b/apps/desktop/src/routes/extension/ui-iframe/+page.svelte
@@ -68,6 +68,7 @@
 		// 	navigateTo(localePath("/"))
 		// },
 		goBack: async () => {
+			console.log("goBack iframe ui API called")
 			if (isInMainWindow()) {
 				goto("/")
 			} else {
@@ -132,6 +133,7 @@
 	} satisfies IApp
 
 	function onBackBtnClicked() {
+		console.log("onBackBtnClicked")
 		if (isInMainWindow()) {
 			goHome()
 		} else {
@@ -173,13 +175,12 @@
 		class={cn("absolute", positionToTailwindClasses(uiControl.backBtnPosition))}
 		size="icon"
 		variant="outline"
-		data-tauri-drag-region
 		onclick={onBackBtnClicked}
 	>
 		{#if appWin.label === "main"}
-			<ArrowLeftIcon class="w-4" data-tauri-drag-region />
+			<ArrowLeftIcon class="w-4" />
 		{:else}
-			<XIcon class="w-4" data-tauri-drag-region />
+			<XIcon class="w-4" />
 		{/if}
 	</Button>
 {/if}
@@ -198,7 +199,6 @@
 		class={cn("absolute", positionToTailwindClasses(uiControl.refreshBtnPosition))}
 		size="icon"
 		variant="outline"
-		data-tauri-drag-region
 		onclick={iframeUiAPI.reloadPage}
 	>
 		<RefreshCcwIcon class="w-4" />

--- a/apps/desktop/src/routes/settings/+page.svelte
+++ b/apps/desktop/src/routes/settings/+page.svelte
@@ -47,9 +47,9 @@
 				<Switch bind:checked={$appConfig} />
 			</li> -->
 	</ul>
-	{#if dev}
+	<!-- {#if dev}
 		<Shiki class="w-full overflow-x-auto" lang="json" code={JSON.stringify($appConfig, null, 2)} />
-	{/if}
+	{/if} -->
 </main>
 
 <style scoped>

--- a/packages/api/src/commands/extension.ts
+++ b/packages/api/src/commands/extension.ts
@@ -31,6 +31,12 @@ export function unregisterExtensionWindow(label: string): Promise<void> {
 	})
 }
 
+export function spawnExtensionFileServer(windowLabel: string): Promise<string> {
+	return invoke<string>(generateJarvisPluginCommand("spawn_extension_file_server"), {
+		windowLabel
+	})
+}
+
 export function registerExtensionSpawnedProcess(windowLabel: string, pid: number): Promise<void> {
 	return invoke(generateJarvisPluginCommand("register_extension_spawned_process"), {
 		windowLabel,

--- a/packages/tauri-plugins/jarvis/build.rs
+++ b/packages/tauri-plugins/jarvis/build.rs
@@ -62,6 +62,7 @@ const COMMANDS: &[&str] = &[
     "register_extension_spawned_process",
     "unregister_extension_spawned_process",
     "unregister_extension_window",
+    "spawn_extension_file_server",
     "get_ext_label_map",
     // "ext_store_wrapper_set",
     // "ext_store_wrapper_get",

--- a/packages/tauri-plugins/jarvis/permissions/all.toml
+++ b/packages/tauri-plugins/jarvis/permissions/all.toml
@@ -58,6 +58,7 @@ commands.allow = [
     "is_window_label_registered",
     "register_extension_window",
     "unregister_extension_window",
+    "spawn_extension_file_server",
     "register_extension_spawned_process",
     "unregister_extension_spawned_process",
     "get_ext_label_map",

--- a/packages/tauri-plugins/jarvis/permissions/autogenerated/commands/spawn_extension_file_server.toml
+++ b/packages/tauri-plugins/jarvis/permissions/autogenerated/commands/spawn_extension_file_server.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-spawn-extension-file-server"
+description = "Enables the spawn_extension_file_server command without any pre-configured scope."
+commands.allow = ["spawn_extension_file_server"]
+
+[[permission]]
+identifier = "deny-spawn-extension-file-server"
+description = "Denies the spawn_extension_file_server command without any pre-configured scope."
+commands.deny = ["spawn_extension_file_server"]

--- a/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
+++ b/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
@@ -1610,6 +1610,32 @@ Denies the sleep_displays command without any pre-configured scope.
 <tr>
 <td>
 
+`jarvis:allow-spawn-extension-file-server`
+
+</td>
+<td>
+
+Enables the spawn_extension_file_server command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`jarvis:deny-spawn-extension-file-server`
+
+</td>
+<td>
+
+Denies the spawn_extension_file_server command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `jarvis:allow-start-server`
 
 </td>

--- a/packages/tauri-plugins/jarvis/permissions/schemas/schema.json
+++ b/packages/tauri-plugins/jarvis/permissions/schemas/schema.json
@@ -910,6 +910,16 @@
           "const": "deny-sleep-displays"
         },
         {
+          "description": "Enables the spawn_extension_file_server command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-spawn-extension-file-server"
+        },
+        {
+          "description": "Denies the spawn_extension_file_server command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-spawn-extension-file-server"
+        },
+        {
           "description": "Enables the start_server command without any pre-configured scope.",
           "type": "string",
           "const": "allow-start-server"

--- a/packages/tauri-plugins/jarvis/src/lib.rs
+++ b/packages/tauri-plugins/jarvis/src/lib.rs
@@ -125,6 +125,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::extension::register_extension_spawned_process,
             commands::extension::unregister_extension_spawned_process,
             commands::extension::get_ext_label_map,
+            commands::extension::spawn_extension_file_server,
             /* ---------------------- extension storage API wrapper --------------------- */
             // commands::storage::ext_store_wrapper_set,
             // commands::storage::ext_store_wrapper_get,

--- a/packages/tauri-plugins/jarvis/src/model/extension.rs
+++ b/packages/tauri-plugins/jarvis/src/model/extension.rs
@@ -1,11 +1,22 @@
 use super::manifest::Permissions;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Extension {
+pub struct ExtensionInfo {
     pub path: PathBuf,
     pub processes: Vec<u32>,
     pub dist: Option<String>,
     // pub identifier: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Extension {
+    pub info: ExtensionInfo,
+    pub shutdown_handle: Arc<Mutex<Option<axum_server::Handle>>>,
+    pub server_handle: Arc<std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>>,
 }


### PR DESCRIPTION
On windows, when custom UI command is triggered, a static file server is spawn on the path: `<extension path>/<dist>`

`dist` is specified in `package.json`.

iframe will load web page from this file server instead of custom protocol `ext://` used on Mac and Linux.
See Issue #4 for the reason of this workaround.