### PR TITLE
perf(splashscreen): make splashscreen prerenderred, slightly faster

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
 			},
 			{
 				"url": "/splashscreen",
-				"visible": false,
+				"visible": true,
 				"label": "splashscreen"
 			}
 		]

--- a/apps/desktop/src/routes/splashscreen/+page.ts
+++ b/apps/desktop/src/routes/splashscreen/+page.ts
@@ -1,0 +1,3 @@
+export const prerender = true
+export const ssr = true
+export const csr = false


### PR DESCRIPTION
Previous splash-screen was CSR. 
Speed improvement around 5 frames in 30fps, so ~1/6s faster. 
It's not necessary, not a big difference, but pre-rendered splash-screen makes more sense.