### PR TITLE
fix(desktop): update deeplink route for extension store

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kksh/desktop",
-	"version": "0.1.20",
+	"version": "0.1.21",
 	"description": "",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src/lib/utils/deeplink.ts
+++ b/apps/desktop/src/lib/utils/deeplink.ts
@@ -58,7 +58,7 @@ export async function handleKunkunProtocol(parsedUrl: URL) {
 		const parsed = v.parse(StorePathSearchParams, params)
 		openMainWindow()
 		if (parsed.identifier) {
-			goto(`/extension/store/${parsed.identifier}`)
+			goto(i18n.resolveRoute(`/app/extension/store/${parsed.identifier}`))
 		} else {
 			goto(i18n.resolveRoute("/app/extension/store"))
 		}
@@ -66,7 +66,7 @@ export async function handleKunkunProtocol(parsedUrl: URL) {
 		emitRefreshDevExt()
 	} else if (href.startsWith(DEEP_LINK_PATH_AUTH_CONFIRM)) {
 		openMainWindow()
-		goto(`/auth/confirm?${parsedUrl.searchParams.toString()}`)
+		goto(i18n.resolveRoute(`/app/auth/confirm?${parsedUrl.searchParams.toString()}`))
 	} else {
 		console.error("Invalid path:", pathname)
 		toast.error("Invalid path", {


### PR DESCRIPTION
Since most routes are moved under `/app`, previous deep links will fail.