### PR TITLE
Fixes kunkunsh/kunkun#104

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
 				"width": 800,
 				"visible": false,
 				"height": 600,
-				"decorations": true
+				"decorations": false,
+				"transparent": true
 			},
 			{
 				"url": "/splashscreen",

--- a/apps/desktop/src/app.html
+++ b/apps/desktop/src/app.html
@@ -7,7 +7,7 @@
 		<title>Kunkun Desktop App</title>
 		%sveltekit.head%
 	</head>
-	<body data-sveltekit-preload-data="hover">
+	<body data-sveltekit-preload-data="hover" class="bg-transparent">
 		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 <ParaglideJS {i18n}>
 	<ModeWatcher />
 	<Toaster richColors closeButton />
-	<ThemeWrapper class="bg-background">
+	<ThemeWrapper>
 		{@render children()}
 	</ThemeWrapper>
 </ParaglideJS>

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 <ParaglideJS {i18n}>
 	<ModeWatcher />
 	<Toaster richColors closeButton />
-	<ThemeWrapper>
+	<ThemeWrapper class="bg-background">
 		{@render children()}
 	</ThemeWrapper>
 </ParaglideJS>


### PR DESCRIPTION
Fixes issue #104 and floating behavior works as expected after tweaks to the window configuration in `tauri.conf.json` and updated client body transparency with some caveats
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/5e7d67f4-07ab-4f8d-9f7f-a3c96f881d02" />

**Caveats**
- window may not be visible on first startup if the process is blocked before the UI is rendered (window becomes visible after the blocking task is completed)
- pages that rely on the window being non-transparent appears with a transparent background