### PR TITLE
Feature: i18n - Added Portuguese translations for app interface

### DIFF
--- a/apps/desktop/messages/pt.json
+++ b/apps/desktop/messages/pt.json
@@ -1,0 +1,82 @@
+{
+	"$schema": "https://inlang.com/schema/inlang-message-format",
+
+	"app_name": "KunKun",
+	"secondary_app_name": "KunKun",
+
+	"common_edit": "Editar",
+	"common_clear": "Limpar",
+	"common_check": "Verificar",
+	"common_install": "Instalar",
+
+	"home_command_input_placeholder": "Digite \"\/\" para buscar...",
+	"home_command_input_dropdown_quit": "Sair",
+	"home_command_input_dropdown_developer_title": "Desenvolvedor",
+	"home_command_input_dropdown_close_window": "Fechar Janela",
+	"home_command_input_dropdown_toggle_devtools": "Alternar Ferramentas de Desenvolvedor",
+	"home_command_input_dropdown_reload_window": "Recarregar Janela",
+	"home_command_input_dropdown_open_preference": "Abrir Preferências",
+	"home_command_input_dropdown_toggle_dev_extension_hmr": "Alternar HMR de Extensão de Desenvolvedor",
+
+	"command_group_heading_dev_ext": "Extensões de Desenvolvedor",
+	"command_group_heading_ext": "Extensões",
+	"command_group_heading_quick_links": "Links Rápidos",
+
+	"settings_menu_settings": "Configurações",
+	"settings_menu_general": "Geral",
+	"settings_menu_developer": "Desenvolvedor",
+	"settings_menu_extensions": "Extensões",
+	"settings_menu_set_dev_ext": "Definir Extensão de Desenvolvedor",
+	"settings_menu_add_dev_ext": "Adicionar Extensão de Desenvolvedor",
+	"settings_menu_about": "Sobre",
+
+	"settings_general_launch_at_login": "Iniciar ao Fazer Login",
+	"settings_general_hotkey": "Tecla de Atalho",
+	"settings_general_menu_bar_icon": "Ícone na Barra de Menu",
+	"settings_general_hide_on_blur": "Ocultar ao Perder Foco",
+	"settings_general_extension_auto_upgrade": "Atualização Automática de Extensões",
+	"settings_general_dev_extension_hmr": "HMR de Extensão de Desenvolvedor",
+	"settings_general_join_beta_updates": "Participar das Atualizações Beta",
+	"settings_general_developer_mode": "Modo Desenvolvedor",
+	"settings_general_language": "Idioma",
+
+	"settings_about_version": "Versão",
+	"settings_about_author": "Autor",
+	"settings_about_source_code": "Código Fonte",
+	"settings_about_extensions_source_code": "Código Fonte das Extensões",
+	"settings_about_check_for_updates": "Verificar Atualizações",
+
+	"settings_set_dev_ext_title": "Definir Caminho da Extensão de Desenvolvedor",
+	"settings_set_dev_ext_description": "Aqui é onde suas extensões serão instaladas.",
+	"settings_set_dev_ext_enter_path": "Digite o Caminho",
+
+	"settings_extensions_title": "Suas Extensões",
+	"settings_extensions_table_col_name": "Nome",
+	"settings_extensions_table_col_identifier": "Identificador",
+	"settings_extensions_table_col_type": "Tipo",
+	"settings_extensions_table_col_version": "Versão",
+	"settings_extensions_table_col_uninstall": "Desinstalar",
+
+	"settings_add_dev_ext_title": "Adicionar Extensão de Desenvolvedor",
+	"settings_add_dev_ext_description": "Existem 4 opções para instalar uma extensão em modo desenvolvedor. Você pode carregá-la de um arquivo tarball local, pasta local, URL remota de tarball ou nome de pacote npm.",
+	"settings_add_dev_ext_install_from_ext_folders": "Instalar de Pastas de Extensão",
+	"settings_add_dev_ext_install_from_ext_files": "Instalar de Arquivo Tarball de Extensão",
+	"settings_add_dev_ext_drag_and_drop": "Arraste e Solte",
+	"settings_add_dev_ext_drag_and_drop2": "Pasta ou Tarball da Extensão",
+	"settings_add_dev_ext_install_tarball_from_url": "Instalar Tarball da URL",
+
+	"troubleshooters_sidebar_title": "Solucionadores de Problemas",
+	"troubleshooters_sidebar_extension_loading_title": "Carregamento de Extensão",
+	"troubleshooters_sidebar_extension_window_title": "Janela da Extensão",
+	"troubleshooters_sidebar_mdns_debugger_title": "Depurador MDNS",
+
+	"troubleshooters_extension_window_title": "Solucionador de Problemas da Janela de Extensão",
+	"troubleshooters_extension_window_refresh_every_second": "Atualizar a Cada Segundo",
+	"troubleshooters_extension_window_refresh": "Atualizar",
+	"troubleshooters_extension_window_refreshed": "Atualizado {count} vezes",
+
+	"troubleshooters_extension_loading_title": "Solucionador de Problemas do Carregamento de Extensão",
+	"troubleshooters_extension_loading_table_col_identifier": "Identificador",
+	"troubleshooters_extension_loading_table_col_path": "Caminho",
+	"troubleshooters_extension_loading_table_col_error": "Erro"
+}


### PR DESCRIPTION
### Description
This PR adds Portuguese translations (pt.json) for the app interface.

### Changes
- Added a new i18n file for Portuguese translations.

As a native Portuguese speaker, I have ensured the accuracy of the translations. I'm willing to make any adjustments as necessary.