### PR TITLE
Add reload button for dev extensions

### DIFF
--- a/apps/desktop/src/lib/stores/extensions.ts
+++ b/apps/desktop/src/lib/stores/extensions.ts
@@ -24,6 +24,7 @@ function createExtensionsStore(): Writable<ExtPackageJsonExtra[]> & {
 	registerNewExtensionByPath: (extPath: string) => Promise<ExtPackageJsonExtra>
 	uninstallStoreExtensionByIdentifier: (identifier: string) => Promise<ExtPackageJsonExtra>
 	uninstallDevExtensionByIdentifier: (identifier: string) => Promise<ExtPackageJsonExtra>
+	reloadDevExtensionByIdentifier: (identifier: string) => Promise<ExtPackageJsonExtra>
 	upgradeStoreExtension: (
 		identifier: string,
 		tarballUrl: string,
@@ -172,6 +173,17 @@ function createExtensionsStore(): Writable<ExtPackageJsonExtra[]> & {
 		return uninstallDevExtensionByPath(targetExt.extPath)
 	}
 
+	async function reloadDevExtensionByIdentifier(
+		identifier: string
+	): Promise<ExtPackageJsonExtra> {
+		const targetExt = getDevExtensions().find((ext) => ext.kunkun.identifier === identifier)
+		if (!targetExt) throw new Error(`Extension ${identifier} not found`)
+
+		// somehow impl a transaction here?
+		await uninstallDevExtensionByPath(targetExt.extPath)
+		return installDevExtensionDir(targetExt.extPath)
+	}
+
 	async function uninstallStoreExtensionByIdentifier(
 		identifier: string
 	): Promise<ExtPackageJsonExtra> {
@@ -204,6 +216,7 @@ function createExtensionsStore(): Writable<ExtPackageJsonExtra[]> & {
 		installFromNpmPackageName,
 		uninstallStoreExtensionByIdentifier,
 		uninstallDevExtensionByIdentifier,
+		reloadDevExtensionByIdentifier,
 		upgradeStoreExtension
 	}
 }

--- a/apps/desktop/src/lib/stores/extensions.ts
+++ b/apps/desktop/src/lib/stores/extensions.ts
@@ -179,6 +179,11 @@ function createExtensionsStore(): Writable<ExtPackageJsonExtra[]> & {
 		const targetExt = getDevExtensions().find((ext) => ext.kunkun.identifier === identifier)
 		if (!targetExt) throw new Error(`Extension ${identifier} not found`)
 
+		// only support reloading dev extensions at the moment
+		const extContainerPath = get(appConfig).extensionsInstallDir
+		const isDev = extContainerPath && extAPI.isExtPathInDev(extContainerPath, targetExt.extPath)
+		if (!isDev) throw new Error("Only dev extensions can be reloaded")
+
 		// somehow impl a transaction here?
 		await uninstallDevExtensionByPath(targetExt.extPath)
 		return installDevExtensionDir(targetExt.extPath)

--- a/apps/desktop/src/routes/app/settings/extensions/+page.svelte
+++ b/apps/desktop/src/routes/app/settings/extensions/+page.svelte
@@ -5,11 +5,12 @@
 	import * as extAPI from "@kksh/extension"
 	import { Button, Table } from "@kksh/svelte5"
 	import { error } from "@tauri-apps/plugin-log"
-	import { TrashIcon } from "lucide-svelte"
+	import { TrashIcon, RefreshCcwIcon } from "lucide-svelte"
 	import { toast } from "svelte-sonner"
 	import { derived, get } from "svelte/store"
 
 	let uninstalling = $state(false)
+	let reloading = $state(false)
 
 	function onUninstall(ext: ExtPackageJsonExtra) {
 		uninstalling = true
@@ -32,13 +33,49 @@
 				uninstalling = false
 			})
 	}
+
+	function onReload(ext: ExtPackageJsonExtra) {
+		// only support reloading dev extensions at the moment
+		const extContainerPath = get(appConfig).extensionsInstallDir
+		const isDev = extContainerPath && extAPI.isExtPathInDev(extContainerPath, ext.extPath)
+		if (!isDev) {
+			toast.warning("Only dev extensions can be reloaded")
+			return
+		}
+
+		reloading = true
+
+		return extensions.reloadDevExtensionByIdentifier(ext.kunkun.identifier)
+			.then((ext) => {
+				toast.success(`${ext.name} Reloaded`)
+			})
+			.catch((err) => {
+				toast.error("Fail to reload dev extension", { description: err })
+				error(`Fail to reload dev extension (${ext.kunkun.identifier}): ${err}`)
+			})
+			.finally(() => {
+				reloading = false
+			})
+	}
 </script>
 
 {#snippet extRow(ext: ExtPackageJsonExtra, type: "Dev Extension" | "Extension")}
 	<Table.Row>
 		<Table.Cell class="font-medium">{ext.kunkun.name}</Table.Cell>
 		<Table.Cell class="">{ext.kunkun.identifier}</Table.Cell>
-		<Table.Cell>{type}</Table.Cell>
+		<Table.Cell>
+			{#if type === "Dev Extension"}
+				<Button
+				variant="secondary"
+				size="icon"
+				disabled={reloading}
+				onclick={() => onReload(ext)}
+				>
+					<RefreshCcwIcon />
+				</Button>
+			{/if}
+			{type}
+		</Table.Cell>
 		<Table.Cell>{ext.version}</Table.Cell>
 		<Table.Cell>
 			<Button

--- a/apps/desktop/src/routes/app/settings/extensions/+page.svelte
+++ b/apps/desktop/src/routes/app/settings/extensions/+page.svelte
@@ -35,14 +35,6 @@
 	}
 
 	function onReload(ext: ExtPackageJsonExtra) {
-		// only support reloading dev extensions at the moment
-		const extContainerPath = get(appConfig).extensionsInstallDir
-		const isDev = extContainerPath && extAPI.isExtPathInDev(extContainerPath, ext.extPath)
-		if (!isDev) {
-			toast.warning("Only dev extensions can be reloaded")
-			return
-		}
-
 		reloading = true
 
 		return extensions.reloadDevExtensionByIdentifier(ext.kunkun.identifier)


### PR DESCRIPTION
Added a reload button ONLY for dev extension.
![image](https://github.com/user-attachments/assets/208f9de8-c525-4ee1-b382-0e351287a153)

It is useful for developer to be able to reload the extensions' metadata (not just logic hot reloading), especially for new extensions where the metadata may be constantly changed (adding new commands for example).

This is just a native way to reload an extension by uninstalling and reinstalling it again. It works with locally developed extensions.