### PR TITLE
feat(desktop): expand file system access permissions to all paths

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -111,28 +111,7 @@
 			"identifier": "fs:scope",
 			"allow": [
 				{
-					"path": "$DESKTOP"
-				},
-				{
-					"path": "$DESKTOP/**"
-				},
-				{
-					"path": "$DOWNLOAD"
-				},
-				{
-					"path": "$DOWNLOAD/**"
-				},
-				{
-					"path": "$DOCUMENT"
-				},
-				{
-					"path": "$DOCUMENT/**"
-				},
-				{
-					"path": "$TEMP/**"
-				},
-				{
-					"path": "$TEMP"
+					"path": "**/*"
 				}
 			]
 		},


### PR DESCRIPTION
closes #136 

People may have extensions installed on different drives. Kunkun was restricted to only a few common dirs for security, but to support this special case Kunkun needs to access all paths.