### PR TITLE
add toggle cli command to show/hide kunkun

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Mutex};
+use std::path::PathBuf;
 pub mod commands;
 mod setup;
 pub mod utils;
@@ -10,18 +10,11 @@ use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_jarvis::{
-    constants::KUNKUN_PUBLISH,
-    db::JarvisDB,
-    server::Protocol,
-    utils::{
-        path::{get_default_extensions_dir, get_kunkun_db_path},
-        settings::AppSettings,
-    },
+    constants::KUNKUN_PUBLISH, server::Protocol, utils::path::get_kunkun_db_path,
 };
-use tauri_plugin_keyring::KeyringExt;
-pub use tauri_plugin_log::fern::colors::ColoredLevelConfig;
-use tauri_plugin_store::{StoreBuilder, StoreExt};
 use utils::server::tauri_file_server;
+
+pub use tauri_plugin_log::fern::colors::ColoredLevelConfig;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -72,7 +65,21 @@ pub fn run() {
     }
     let shell_unlocked = true;
     builder = builder
-        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+            if let Some(second_arg) = args.get(1) {
+                // toggle (show/hide) main window
+                if second_arg == "toggle" {
+                    let window = app.get_webview_window("main").expect("no main window");
+                    if window.is_visible().is_ok_and(|visible| visible == false) {
+                        log::info!("showing main window");
+                        window.show().unwrap();
+                    } else {
+                        log::info!("hiding main window");
+                        window.hide().unwrap();
+                    };
+                }
+            }
+
             let _ = app
                 .get_webview_window("main")
                 .expect("no main window")

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Mutex};
 pub mod commands;
 mod setup;
 pub mod utils;
@@ -10,11 +10,18 @@ use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_jarvis::{
-    constants::KUNKUN_PUBLISH, server::Protocol, utils::path::get_kunkun_db_path,
+    constants::KUNKUN_PUBLISH,
+    db::JarvisDB,
+    server::Protocol,
+    utils::{
+        path::{get_default_extensions_dir, get_kunkun_db_path},
+        settings::AppSettings,
+    },
 };
-use utils::server::tauri_file_server;
-
+use tauri_plugin_keyring::KeyringExt;
 pub use tauri_plugin_log::fern::colors::ColoredLevelConfig;
+use tauri_plugin_store::{StoreBuilder, StoreExt};
+use utils::server::tauri_file_server;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -66,24 +66,21 @@ pub fn run() {
     let shell_unlocked = true;
     builder = builder
         .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            if let Some(second_arg) = args.get(1) {
-                // toggle (show/hide) main window
-                if second_arg == "toggle" {
-                    let window = app.get_webview_window("main").expect("no main window");
-                    if window.is_visible().is_ok_and(|visible| visible == false) {
-                        log::info!("showing main window");
-                        window.show().unwrap();
-                    } else {
-                        log::info!("hiding main window");
-                        window.hide().unwrap();
-                    };
-                }
-            }
+            let window = app.get_webview_window("main").expect("no main window");
 
-            let _ = app
-                .get_webview_window("main")
-                .expect("no main window")
-                .set_focus();
+            // if toggle is passed, we want to show/hide the main window
+            if args.get(1).map_or(false, |arg| arg == "toggle") {
+                if window.is_visible().unwrap_or(false) {
+                    log::info!("hiding main window");
+                    window.hide().unwrap();
+                } else {
+                    log::info!("showing main window");
+                    window.show().unwrap();
+                    window.set_focus().unwrap();
+                };
+            } else {
+                let _ = window.set_focus();
+            }
         }))
         .plugin(
             tauri_plugin_log::Builder::new()


### PR DESCRIPTION
Wanted to try out kunkun, but due to using sway (wayland)(similair for i3,hyprland, etc) , there is no way to set the global keybinding. 
https://github.com/tauri-apps/global-hotkey/issues/28
Perhaps doing as "Exidex on Dec 4, 2024" said, using [https://github.com/bilelmoussaoui/ashpd](ashpd) directly might be good for other users.


It is really rare for a linux application to have its own global keybinding. Which is why it has taken a while for wayland to support it.

This pr allows you to call kunkun with:
```
kunkun toggle
```

And will toggle the visibility (show/hide) of kunkun.
This way without using the global keybinding, you can use kunkun on linux with configuring your WM/DE directly.
Example for sway:
```
# just stuff for floating and make it always center
for_window [app_id="kunkun"] floating enable
for_window [app_id="kunkun"] move absolute position center
# binding to toggle visibility
bindsym $mod+K exec "kunkun toggle"
```

# Testing
Have only tested this on linux with sway.

Let me know if this is desired for the project or not.