### PR TITLE
feat(shell): add hidden window style to PowerShell script execution

### DIFF
--- a/packages/api/src/api/server/shell.ts
+++ b/packages/api/src/api/server/shell.ts
@@ -168,7 +168,7 @@ export function constructShellApi(
 			ShellPermissionMap.executePowershellScript,
 			objectPermissions,
 			"powershell",
-			["-Command", script]
+			["-WindowStyle", "Hidden", "-Command", script]
 		)
 		return executePowershellScript(script)
 	}

--- a/packages/tauri-plugins/jarvis/src/utils/script.rs
+++ b/packages/tauri-plugins/jarvis/src/utils/script.rs
@@ -17,6 +17,8 @@ pub fn run_apple_script(script: &str) -> anyhow::Result<String> {
 
 pub fn run_powershell(script: &str) -> anyhow::Result<String> {
     let output = Command::new("powershell")
+        .arg("-WindowStyle")
+        .arg("Hidden")
         .arg("-Command")
         .arg(script)
         .output()


### PR DESCRIPTION
Modify PowerShell script execution to run with hidden window style in both TypeScript API and Rust plugin to prevent visible command windows