### PR TITLE
Fix: linux extension loading

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kksh/desktop",
-	"version": "0.1.24",
+	"version": "0.1.25",
 	"description": "",
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src/lib/cmds/ext.ts
+++ b/apps/desktop/src/lib/cmds/ext.ts
@@ -163,7 +163,8 @@ export async function onCustomUiCmdSelect(
 			extPath: ext.extPath,
 			dist: cmd.dist
 		})
-		if (platform() === "windows" && !useDevMain) {
+		const _platform = platform()
+		if ((_platform === "windows" || _platform === "linux") && !useDevMain) {
 			const addr = await spawnExtensionFileServer(winLabel) // addr has format "127.0.0.1:<port>"
 			console.log("Extension file server address: ", addr)
 			const newUrl = `http://${addr}`

--- a/apps/desktop/src/routes/app/extension/store/+page.svelte
+++ b/apps/desktop/src/routes/app/extension/store/+page.svelte
@@ -111,7 +111,7 @@
 	function onkeydown(e: KeyboardEvent) {
 		if (e.key === "Escape") {
 			if (document.activeElement === listviewInputRef) {
-				goBack()
+				goHome()
 			}
 		}
 	}

--- a/deno.lock
+++ b/deno.lock
@@ -181,6 +181,7 @@
     "npm:tauri-api-adapter@~0.3.20": "0.3.20_typescript@5.6.3",
     "npm:tauri-plugin-clipboard-api@^2.1.11": "2.1.11_typescript@5.6.3",
     "npm:tauri-plugin-shellx-api@^2.0.14": "2.0.14",
+    "npm:tauri-plugin-system-info-api@2.0.8": "2.0.8_typescript@5.6.3",
     "npm:ts-proto@^2.3.0": "2.6.1",
     "npm:tslib@^2.8.1": "2.8.1",
     "npm:turbo@^2.3.4": "2.4.0",


### PR DESCRIPTION
This is a temporary fix. 
See https://github.com/tauri-apps/tauri/issues/12767 for more info.
Tauri's asset protocol has another problem with Windows, I spawn http server on Windows to serve custom UI extensions files. The same fix can solve the problem with Linux.

Related issue: https://github.com/kunkunsh/kunkun/issues/186
