### PR TITLE
fix(desktop): set macOS accessory activation policy to Accessory

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -230,7 +230,8 @@ pub fn run() {
             }
             // setup::deeplink::setup_deeplink(app);
             // #[cfg(all(target_os = "macos", debug_assertions))]
-            // app.set_activation_policy(ActivationPolicy::Accessory);
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(ActivationPolicy::Accessory);
             // let mut store = StoreBuilder::new("appConfig.bin").build(app.handle().clone());
             // let store = app.handle().store_builder("appConfig.json").build()?;
 


### PR DESCRIPTION
closes #104 
closes #184

Simply `app.set_activation_policy(ActivationPolicy::Accessory);` for macOS


