### PR TITLE
only show apps with name

### DIFF
--- a/apps/desktop/src/lib/components/main/AppsCmds.svelte
+++ b/apps/desktop/src/lib/components/main/AppsCmds.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <DraggableCommandGroup heading="Apps">
-	{#each apps.filter(app => app.name) as app}
+	{#each apps.filter((app) => app.name) as app}
 		<Command.Item
 			class="flex justify-between"
 			onSelect={() => {

--- a/apps/desktop/src/lib/components/main/AppsCmds.svelte
+++ b/apps/desktop/src/lib/components/main/AppsCmds.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <DraggableCommandGroup heading="Apps">
-	{#each apps as app}
+	{#each apps.filter(app => app.name) as app}
 		<Command.Item
 			class="flex justify-between"
 			onSelect={() => {

--- a/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
+++ b/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
@@ -1,4 +1,3 @@
-
 ## Permission Table
 
 <table>
@@ -6,7 +5,6 @@
 <th>Identifier</th>
 <th>Description</th>
 </tr>
-
 
 <tr>
 <td>

--- a/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
+++ b/packages/tauri-plugins/jarvis/permissions/autogenerated/reference.md
@@ -1,3 +1,4 @@
+
 ## Permission Table
 
 <table>
@@ -5,6 +6,7 @@
 <th>Identifier</th>
 <th>Description</th>
 </tr>
+
 
 <tr>
 <td>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,7 +814,7 @@ importers:
         version: 11.0.3
     devDependencies:
       '@types/bun':
-        specifier: 1.2.3
+        specifier: latest
         version: 1.2.3
 
   packages/templates/template-ext-next:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,8 +814,8 @@ importers:
         version: 11.0.3
     devDependencies:
       '@types/bun':
-        specifier: latest
-        version: 1.2.2
+        specifier: 1.2.3
+        version: 1.2.3
 
   packages/templates/template-ext-next:
     dependencies:
@@ -5130,6 +5130,9 @@ packages:
   '@types/bun@1.2.2':
     resolution: {integrity: sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w==}
 
+  '@types/bun@1.2.3':
+    resolution: {integrity: sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -6179,6 +6182,9 @@ packages:
 
   bun-types@1.2.2:
     resolution: {integrity: sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg==}
+
+  bun-types@1.2.3:
+    resolution: {integrity: sha512-P7AeyTseLKAvgaZqQrvp3RqFM3yN9PlcLuSTe7SoJOfZkER73mLdT2vEQi8U64S1YvM/ldcNiQjn0Sn7H9lGgg==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -16633,6 +16639,10 @@ snapshots:
     dependencies:
       bun-types: 1.2.2
 
+  '@types/bun@1.2.3':
+    dependencies:
+      bun-types: 1.2.3
+
   '@types/cookie@0.6.0': {}
 
   '@types/d3-array@3.2.1': {}
@@ -18179,6 +18189,11 @@ snapshots:
       ieee754: 1.2.1
 
   bun-types@1.2.2:
+    dependencies:
+      '@types/node': 22.13.1
+      '@types/ws': 8.5.14
+
+  bun-types@1.2.3:
     dependencies:
       '@types/node': 22.13.1
       '@types/ws': 8.5.14


### PR DESCRIPTION
Not sure if the apps list generated should skip applications without a name, or if we want to filter it on the frontend.

I don't see a reason why to keep applications which don't have a name set, think it is probably better to not merge this.
But to change the app loading to only the ones with basic info like name.
(Also perhaps an idea to have the applications in order instead of random? (( don't think it actually matters? perhaps for consistent searching if the searching matters on ordering)) )

![image](https://github.com/user-attachments/assets/d8ba7740-6f50-40c5-9712-e58d3000d767)
![image](https://github.com/user-attachments/assets/440a690f-1951-41ca-99d6-65b2f993b404)

(Need this as when hovering over an item without a name it moves the view to the top of the page.)