### PR TITLE
exit and clear search term after onSelect

### DIFF
--- a/apps/desktop/src/lib/components/main/AppsCmds.svelte
+++ b/apps/desktop/src/lib/components/main/AppsCmds.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { appState } from "@/stores"
 	import { IconEnum, type AppInfo } from "@kksh/api/models"
 	import { Command } from "@kksh/svelte5"
 	import { IconMultiplexer } from "@kksh/ui"
@@ -11,13 +12,6 @@
 
 	const platform = os.platform()
 	let { apps }: { apps: AppInfo[] } = $props()
-
-	// remove extra "%u"/"%U"/"%F" from the command
-	function cleanAppPath(path: string): string {
-		let command = path.replace(/%\w+/g, "").trim()
-		command = command.replace(/\s+/g, " ")
-		return command
-	}
 </script>
 
 <DraggableCommandGroup heading="Apps">
@@ -35,7 +29,7 @@
 					open(app.app_desktop_path)
 				} else if (platform === "linux") {
 					if (app.app_path_exe) {
-						executeBashScript(cleanAppPath(app.app_path_exe))
+						executeBashScript(app.app_path_exe)
 					} else {
 						toast.error("No executable path found for this app")
 					}
@@ -43,6 +37,7 @@
 					toast.error("Unsupported platform")
 				}
 				await getCurrentWindow().hide()
+				appState.clearSearchTerm()
 			}}
 			value={app.app_desktop_path}
 		>

--- a/apps/desktop/src/lib/components/main/AppsCmds.svelte
+++ b/apps/desktop/src/lib/components/main/AppsCmds.svelte
@@ -4,20 +4,20 @@
 	import { IconMultiplexer } from "@kksh/ui"
 	import { DraggableCommandGroup } from "@kksh/ui/custom"
 	import { convertFileSrc } from "@tauri-apps/api/core"
+	import { getCurrentWindow } from "@tauri-apps/api/window"
 	import * as os from "@tauri-apps/plugin-os"
 	import { toast } from "svelte-sonner"
 	import { executeBashScript, open } from "tauri-plugin-shellx-api"
-	import { getCurrentWindow} from "@tauri-apps/api/window"
 
 	const platform = os.platform()
 	let { apps }: { apps: AppInfo[] } = $props()
 
 	// remove extra "%u"/"%U"/"%F" from the command
-    function cleanAppPath(path: string): string {
-		let command = path.replace(/%\w+/g, '').trim()
-		command = command.replace(/\s+/g, ' ')
+	function cleanAppPath(path: string): string {
+		let command = path.replace(/%\w+/g, "").trim()
+		command = command.replace(/\s+/g, " ")
 		return command
-    }
+	}
 </script>
 
 <DraggableCommandGroup heading="Apps">

--- a/apps/desktop/src/lib/components/main/AppsCmds.svelte
+++ b/apps/desktop/src/lib/components/main/AppsCmds.svelte
@@ -7,16 +7,24 @@
 	import * as os from "@tauri-apps/plugin-os"
 	import { toast } from "svelte-sonner"
 	import { executeBashScript, open } from "tauri-plugin-shellx-api"
+	import { getCurrentWindow} from "@tauri-apps/api/window"
 
 	const platform = os.platform()
 	let { apps }: { apps: AppInfo[] } = $props()
+
+	// remove extra "%u"/"%U"/"%F" from the command
+    function cleanAppPath(path: string): string {
+		let command = path.replace(/%\w+/g, '').trim()
+		command = command.replace(/\s+/g, ' ')
+		return command
+    }
 </script>
 
 <DraggableCommandGroup heading="Apps">
 	{#each apps.filter((app) => app.name) as app}
 		<Command.Item
 			class="flex justify-between"
-			onSelect={() => {
+			onSelect={async () => {
 				if (platform === "windows") {
 					if (app.app_path_exe) {
 						open(app.app_path_exe)
@@ -27,13 +35,14 @@
 					open(app.app_desktop_path)
 				} else if (platform === "linux") {
 					if (app.app_path_exe) {
-						executeBashScript(app.app_path_exe)
+						executeBashScript(cleanAppPath(app.app_path_exe))
 					} else {
 						toast.error("No executable path found for this app")
 					}
 				} else {
 					toast.error("Unsupported platform")
 				}
+				await getCurrentWindow().hide()
 			}}
 			value={app.app_desktop_path}
 		>


### PR DESCRIPTION
```
Exec=/usr/lib/firefox/firefox %u

Exec=/usr/bin/code %F
```

`.desktop` files on linux have %stuff for ?arguments?

when running this from bash directly we need to remove it.
Stolen the code from: [backslash handlers.ts](https://github.com/backslash-app/backslash/blob/e83ce7089aeb1faec7e95ba67b56aa478ce285e8/src/main/handlers.ts#L81-L90)

I have `Hide on blur` disabled, and when launching an application it doesn't quit the window.
Think that that is desired  behavior, so the explicit `getCurrentWindow().hide()` has been added.

