### PR TITLE
feat: add custom configurable app search paths

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -24,6 +24,7 @@
 
 	"settings_menu_settings": "Settings",
 	"settings_menu_general": "General",
+	"settings_menu_app_search_paths": "App Search Paths",
 	"settings_menu_developer": "Developer",
 	"settings_menu_extensions": "Extensions",
 	"settings_menu_set_dev_ext": "Set Dev Extension",
@@ -39,6 +40,12 @@
 	"settings_general_join_beta_updates": "Join Beta Updates",
 	"settings_general_developer_mode": "Developer Mode",
 	"settings_general_language": "Language",
+
+	"settings_app_search_paths_title": "Extra App Search Paths",
+	"settings_app_search_paths_add_app_search_path": "Add App Search Path",
+	"settings_app_search_paths_table_col_search_path": "Search Path",
+	"settings_app_search_paths_table_col_depth": "Depth",
+	"settings_app_search_paths_table_col_actions": "Actions",
 
 	"settings_about_version": "Version",
 	"settings_about_author": "Author",

--- a/apps/desktop/messages/zh.json
+++ b/apps/desktop/messages/zh.json
@@ -24,6 +24,7 @@
 
 	"settings_menu_settings": "设置",
 	"settings_menu_general": "通用",
+	"settings_menu_app_search_paths": "应用搜索路径",
 	"settings_menu_developer": "开发者",
 	"settings_menu_extensions": "插件",
 	"settings_menu_set_dev_ext": "设置开发插件",
@@ -39,6 +40,12 @@
 	"settings_general_join_beta_updates": "加入 Beta 更新",
 	"settings_general_developer_mode": "开发者模式",
 	"settings_general_language": "语言",
+
+	"settings_app_search_paths_title": "额外应用搜索路径",
+	"settings_app_search_paths_add_app_search_path": "添加应用搜索路径",
+	"settings_app_search_paths_table_col_search_path": "搜索路径",
+	"settings_app_search_paths_table_col_depth": "深度",
+	"settings_app_search_paths_table_col_actions": "操作",
 
 	"settings_about_version": "版本",
 	"settings_about_author": "作者",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
 		"lz-string": "^1.5.0",
 		"pretty-bytes": "^6.1.1",
 		"semver": "^7.6.3",
-		"svelte-inspect-value": "^0.2.2",
+		"svelte-inspect-value": "^0.3.0",
 		"svelte-sonner": "^0.3.28",
 		"sveltekit-superforms": "^2.22.1",
 		"tauri-plugin-clipboard-api": "^2.1.11",

--- a/apps/desktop/src/lib/stores/appConfig.ts
+++ b/apps/desktop/src/lib/stores/appConfig.ts
@@ -1,5 +1,6 @@
 import { getExtensionsFolder } from "@/constants"
 import { createTauriSyncStore, type WithSyncStore } from "@/utils/sync-store"
+import type { SearchPath } from "@kksh/api/models"
 import { updateTheme, type ThemeConfig } from "@kksh/svelte5"
 import { PersistedAppConfig, type AppConfig } from "@kksh/types"
 import { debug, error } from "@tauri-apps/plugin-log"
@@ -27,7 +28,8 @@ export const defaultAppConfig: AppConfig = {
 	extensionAutoUpgrade: true,
 	joinBetaProgram: false,
 	onBoarded: false,
-	developerMode: false
+	developerMode: false,
+	appSearchPaths: []
 }
 
 export const appConfigLoaded = writable(false)
@@ -40,6 +42,8 @@ interface AppConfigAPI {
 	setTriggerHotkey: (triggerHotkey: string[]) => void
 	setOnBoarded: (onBoarded: boolean) => void
 	setLanguage: (language: string) => void
+	addAppSearchPath: (appSearchPath: SearchPath) => void
+	removeAppSearchPath: (appSearchPath: SearchPath) => void
 }
 
 function createAppConfig(): WithSyncStore<AppConfig & { language: string }> & AppConfigAPI {
@@ -93,6 +97,18 @@ function createAppConfig(): WithSyncStore<AppConfig & { language: string }> & Ap
 		},
 		setLanguage: (language: string) => {
 			store.update((config) => ({ ...config, language }))
+		},
+		addAppSearchPath: (appSearchPath: SearchPath) => {
+			store.update((config) => ({
+				...config,
+				appSearchPaths: [...config.appSearchPaths, appSearchPath]
+			}))
+		},
+		removeAppSearchPath: (appSearchPath: SearchPath) => {
+			store.update((config) => ({
+				...config,
+				appSearchPaths: config.appSearchPaths.filter((path) => path.path !== appSearchPath.path)
+			}))
 		},
 		init
 	}

--- a/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
+++ b/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	import { appsLoader } from "@/stores"
+	import { SearchPath } from "@kksh/api/models"
+	import { Button, Input, Table } from "@kksh/svelte5"
+	import { Form } from "@kksh/ui"
+	import * as dialog from "@tauri-apps/plugin-dialog"
+	import * as fs from "@tauri-apps/plugin-fs"
+	import { appConfig } from "$lib/stores/appConfig"
+	import { Inspect } from "svelte-inspect-value"
+	import { toast } from "svelte-sonner"
+	import SuperDebug, { defaults, superForm } from "sveltekit-superforms"
+	import { valibot, valibotClient } from "sveltekit-superforms/adapters"
+	import { open } from "tauri-plugin-shellx-api"
+	import * as v from "valibot"
+
+	export const SearchPathFormSchema = v.object({
+		path: v.pipe(v.string(), v.minLength(1)),
+		depth: v.optional(v.number(), 1)
+	})
+
+	const form = superForm(defaults(valibot(SearchPathFormSchema)), {
+		validators: valibotClient(SearchPathFormSchema),
+		SPA: true,
+		async onUpdate({ form, cancel }) {
+			if (!form.valid) {
+				return
+			}
+			const { path, depth } = form.data
+			if (!(await fs.exists(path))) {
+				return toast.error("Path does not exist")
+			}
+			appConfig.addAppSearchPath({ path, depth })
+			toast.success("Search Path Added")
+			appsLoader.init()
+			cancel()
+		}
+	})
+	const { form: formData, enhance, errors } = form
+
+	async function pickSearchPath() {
+		const result = await dialog.open({
+			directory: true
+		})
+		if (result) {
+			$formData.path = result
+		}
+	}
+</script>
+
+<main class="container flex flex-col space-y-2">
+	<h1 class="text-2xl font-bold">Extra App Search Paths</h1>
+	{#if $appConfig.developerMode}
+		<Inspect name="Extra App Search Paths" value={$appConfig.appSearchPaths} />
+	{/if}
+	<form method="POST" use:enhance>
+		<Form.Field {form} name="path">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label>Path</Form.Label>
+					<div class="flex items-center gap-1">
+						<Input {...props} disabled bind:value={$formData.path} placeholder="Search Path" />
+						<Form.Button class="my-1" onclick={pickSearchPath}>Pick</Form.Button>
+					</div>
+				{/snippet}
+			</Form.Control>
+			<Form.FieldErrors />
+		</Form.Field>
+		<Form.Field {form} name="depth">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label>Search Depth</Form.Label>
+					<Input {...props} type="number" bind:value={$formData.depth} placeholder="Depth" />
+				{/snippet}
+			</Form.Control>
+			<Form.FieldErrors />
+		</Form.Field>
+		<Button class="w-full" type="submit">Add App Search Path</Button>
+	</form>
+
+	{#if $appConfig.developerMode}
+		<SuperDebug data={$formData} />
+	{/if}
+
+	<Table.Root>
+		<Table.Caption>Your App Search Paths</Table.Caption>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Search Path</Table.Head>
+				<Table.Head class="text-center">Depth</Table.Head>
+				<Table.Head class="text-center">Actions</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each $appConfig.appSearchPaths as appSearchPath, i (i)}
+				<Table.Row>
+					<Table.Cell
+						class="cursor-pointer font-medium"
+						onclick={() => {
+							open(appSearchPath.path)
+						}}
+					>
+						<code>{appSearchPath.path}</code>
+					</Table.Cell>
+					<Table.Cell class="text-center">{appSearchPath.depth}</Table.Cell>
+					<Table.Cell class="text-center">
+						<Button
+							variant="destructive"
+							onclick={() => {
+								appConfig.removeAppSearchPath(appSearchPath)
+								toast.error("Search Path Removed")
+								appsLoader.init()
+							}}
+						>
+							Remove
+						</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
+</main>

--- a/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
+++ b/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
@@ -59,7 +59,12 @@
 				{#snippet children({ props })}
 					<Form.Label>{m.settings_app_search_paths_table_col_search_path()}</Form.Label>
 					<div class="flex items-center gap-1">
-						<Input {...props} disabled bind:value={$formData.path} placeholder={m.settings_app_search_paths_table_col_search_path()} />
+						<Input
+							{...props}
+							disabled
+							bind:value={$formData.path}
+							placeholder={m.settings_app_search_paths_table_col_search_path()}
+						/>
 						<Form.Button class="my-1" onclick={pickSearchPath}>Pick</Form.Button>
 					</div>
 				{/snippet}
@@ -70,7 +75,12 @@
 			<Form.Control>
 				{#snippet children({ props })}
 					<Form.Label>{m.settings_app_search_paths_table_col_depth()}</Form.Label>
-					<Input {...props} type="number" bind:value={$formData.depth} placeholder={m.settings_app_search_paths_table_col_depth()} />
+					<Input
+						{...props}
+						type="number"
+						bind:value={$formData.depth}
+						placeholder={m.settings_app_search_paths_table_col_depth()}
+					/>
 				{/snippet}
 			</Form.Control>
 			<Form.FieldErrors />

--- a/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
+++ b/apps/desktop/src/routes/app/settings/app-search-paths/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as m from "@/paraglide/messages"
 	import { appsLoader } from "@/stores"
 	import { SearchPath } from "@kksh/api/models"
 	import { Button, Input, Table } from "@kksh/svelte5"
@@ -48,7 +49,7 @@
 </script>
 
 <main class="container flex flex-col space-y-2">
-	<h1 class="text-2xl font-bold">Extra App Search Paths</h1>
+	<h1 class="text-2xl font-bold">{m.settings_app_search_paths_title()}</h1>
 	{#if $appConfig.developerMode}
 		<Inspect name="Extra App Search Paths" value={$appConfig.appSearchPaths} />
 	{/if}
@@ -56,9 +57,9 @@
 		<Form.Field {form} name="path">
 			<Form.Control>
 				{#snippet children({ props })}
-					<Form.Label>Path</Form.Label>
+					<Form.Label>{m.settings_app_search_paths_table_col_search_path()}</Form.Label>
 					<div class="flex items-center gap-1">
-						<Input {...props} disabled bind:value={$formData.path} placeholder="Search Path" />
+						<Input {...props} disabled bind:value={$formData.path} placeholder={m.settings_app_search_paths_table_col_search_path()} />
 						<Form.Button class="my-1" onclick={pickSearchPath}>Pick</Form.Button>
 					</div>
 				{/snippet}
@@ -68,13 +69,15 @@
 		<Form.Field {form} name="depth">
 			<Form.Control>
 				{#snippet children({ props })}
-					<Form.Label>Search Depth</Form.Label>
-					<Input {...props} type="number" bind:value={$formData.depth} placeholder="Depth" />
+					<Form.Label>{m.settings_app_search_paths_table_col_depth()}</Form.Label>
+					<Input {...props} type="number" bind:value={$formData.depth} placeholder={m.settings_app_search_paths_table_col_depth()} />
 				{/snippet}
 			</Form.Control>
 			<Form.FieldErrors />
 		</Form.Field>
-		<Button class="w-full" type="submit">Add App Search Path</Button>
+		<Button class="w-full" type="submit">
+			{m.settings_app_search_paths_add_app_search_path()}
+		</Button>
 	</form>
 
 	{#if $appConfig.developerMode}
@@ -82,12 +85,15 @@
 	{/if}
 
 	<Table.Root>
-		<Table.Caption>Your App Search Paths</Table.Caption>
 		<Table.Header>
 			<Table.Row>
-				<Table.Head>Search Path</Table.Head>
-				<Table.Head class="text-center">Depth</Table.Head>
-				<Table.Head class="text-center">Actions</Table.Head>
+				<Table.Head>{m.settings_app_search_paths_table_col_search_path()}</Table.Head>
+				<Table.Head class="text-center">
+					{m.settings_app_search_paths_table_col_depth()}
+				</Table.Head>
+				<Table.Head class="text-center">
+					{m.settings_app_search_paths_table_col_actions()}
+				</Table.Head>
 			</Table.Row>
 		</Table.Header>
 		<Table.Body>

--- a/apps/desktop/src/routes/app/settings/sidebar.svelte
+++ b/apps/desktop/src/routes/app/settings/sidebar.svelte
@@ -4,7 +4,7 @@
 	import { goHome } from "@/utils/route"
 	import { Button, Sidebar } from "@kksh/svelte5"
 	import { Constants } from "@kksh/ui"
-	import { ArrowLeftIcon } from "lucide-svelte"
+	import { ArrowLeftIcon, FolderSearch } from "lucide-svelte"
 	import Blocks from "lucide-svelte/icons/blocks"
 	import Cog from "lucide-svelte/icons/cog"
 	import FileCode2 from "lucide-svelte/icons/file-code-2"
@@ -19,10 +19,15 @@
 			icon: Cog
 		},
 		{
-			title: m.settings_menu_developer(),
-			url: i18n.resolveRoute("/app/settings/developer"),
-			icon: SquareTerminal
+			title: "App Search Paths",
+			url: i18n.resolveRoute("/app/settings/app-search-paths"),
+			icon: FolderSearch
 		},
+		// {
+		// 	title: m.settings_menu_developer(),
+		// 	url: i18n.resolveRoute("/app/settings/developer"),
+		// 	icon: SquareTerminal
+		// },
 		{
 			title: m.settings_menu_extensions(),
 			url: i18n.resolveRoute("/app/settings/extensions"),

--- a/apps/desktop/src/routes/app/settings/sidebar.svelte
+++ b/apps/desktop/src/routes/app/settings/sidebar.svelte
@@ -19,7 +19,7 @@
 			icon: Cog
 		},
 		{
-			title: "App Search Paths",
+			title: m.settings_menu_app_search_paths(),
 			url: i18n.resolveRoute("/app/settings/app-search-paths"),
 			icon: FolderSearch
 		},

--- a/packages/api/src/commands/apps.ts
+++ b/packages/api/src/commands/apps.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core"
-import { AppInfo } from "../models"
+import { AppInfo, SearchPath } from "../models"
 import { generateJarvisPluginCommand } from "./common"
 
 export function getAllApps(): Promise<AppInfo[]> {
@@ -12,6 +12,10 @@ export function refreshApplicationsList(): Promise<void> {
 
 export function refreshApplicationsListInBg(): Promise<void> {
 	return invoke(generateJarvisPluginCommand("refresh_applications_list_in_bg"))
+}
+
+export function setExtraAppSearchPaths(paths: SearchPath[]): Promise<void> {
+	return invoke(generateJarvisPluginCommand("set_extra_app_search_paths"), { paths })
 }
 
 // export function convertAppToTListItem(app: AppInfo): TListItem {

--- a/packages/api/src/models/apps.ts
+++ b/packages/api/src/models/apps.ts
@@ -1,4 +1,4 @@
-import { nullable, object, string, type InferOutput } from "valibot"
+import { nullable, number, object, string, type InferOutput } from "valibot"
 
 export const AppInfo = object({
 	name: string(),
@@ -7,3 +7,9 @@ export const AppInfo = object({
 	app_desktop_path: string()
 })
 export type AppInfo = InferOutput<typeof AppInfo>
+
+export const SearchPath = object({
+	path: string(),
+	depth: number()
+})
+export type SearchPath = InferOutput<typeof SearchPath>

--- a/packages/tauri-plugins/jarvis/src/commands/apps.rs
+++ b/packages/tauri-plugins/jarvis/src/commands/apps.rs
@@ -1,10 +1,11 @@
-use applications::{App, AppInfo, AppInfoContext};
+use applications::{common::SearchPath, App, AppInfo, AppInfoContext};
 use std::sync::Mutex;
 
 #[derive(Default)]
 pub struct ApplicationsState {
     ctx: Mutex<AppInfoContext>,
 }
+
 #[tauri::command]
 pub async fn get_applications(
     state: tauri::State<'_, ApplicationsState>,
@@ -30,5 +31,15 @@ pub async fn refresh_applications_list_in_bg(
     state: tauri::State<'_, ApplicationsState>,
 ) -> Result<(), String> {
     state.ctx.lock().unwrap().refresh_apps_in_background();
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_extra_app_search_paths(
+    state: tauri::State<'_, ApplicationsState>,
+    paths: Vec<SearchPath>,
+) -> Result<(), String> {
+    let mut ctx = state.ctx.lock().unwrap();
+    ctx.extra_search_paths = paths;
     Ok(())
 }

--- a/packages/tauri-plugins/jarvis/src/commands/system.rs
+++ b/packages/tauri-plugins/jarvis/src/commands/system.rs
@@ -130,7 +130,7 @@ pub async fn unmute() -> Result<(), String> {
 
 #[tauri::command]
 pub async fn get_frontmost_app() -> Result<applications::App, String> {
-    let ctx = applications::AppInfoContext::new();
+    let ctx = applications::AppInfoContext::new(vec![]);
     ctx.get_frontmost_application()
         .map_err(|err| err.to_string())
 }

--- a/packages/types/src/appConfig.ts
+++ b/packages/types/src/appConfig.ts
@@ -1,4 +1,4 @@
-import { LightMode } from "@kksh/api/models"
+import { LightMode, SearchPath } from "@kksh/api/models"
 import type { Platform } from "@tauri-apps/plugin-os"
 import * as v from "valibot"
 
@@ -17,7 +17,8 @@ export const PersistedAppConfig = v.object({
 	extensionAutoUpgrade: v.boolean(),
 	joinBetaProgram: v.boolean(),
 	onBoarded: v.boolean(),
-	developerMode: v.boolean()
+	developerMode: v.boolean(),
+	appSearchPaths: v.array(SearchPath)
 })
 
 export type PersistedAppConfig = v.InferOutput<typeof PersistedAppConfig>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -81,7 +81,7 @@
 		"moment": "^2.30.1",
 		"pretty-bytes": "^6.1.1",
 		"shiki-magic-move": "^0.5.2",
-		"svelte-inspect-value": "^0.2.2",
+		"svelte-inspect-value": "^0.3.0",
 		"svelte-markdown": "^0.4.1",
 		"valibot": "1.0.0-beta.12"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
         specifier: ^7.6.3
         version: 7.6.3
       svelte-inspect-value:
-        specifier: ^0.2.2
-        version: 0.2.2(svelte@5.16.6)
+        specifier: ^0.3.0
+        version: 0.3.0(svelte@5.16.6)
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.16.6)
@@ -335,7 +335,7 @@ importers:
         version: 8.23.0(eslint@9.21.0(jiti@2.4.0))(typescript@5.6.3)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.20(postcss@8.5.1)
+        version: 10.4.20(postcss@8.4.49)
       bits-ui:
         specifier: 1.0.0-next.86
         version: 1.0.0-next.86(svelte@5.16.6)
@@ -1241,8 +1241,8 @@ importers:
         specifier: ^5.0.0
         version: 5.16.6
       svelte-inspect-value:
-        specifier: ^0.2.2
-        version: 0.2.2(svelte@5.16.6)
+        specifier: ^0.3.0
+        version: 0.3.0(svelte@5.16.6)
       svelte-markdown:
         specifier: ^0.4.1
         version: 0.4.1(svelte@5.16.6)
@@ -10707,8 +10707,8 @@ packages:
       svelte:
         optional: true
 
-  svelte-inspect-value@0.2.2:
-    resolution: {integrity: sha512-Ly4QcIDoPo2O81CdIhx600bBaQdla65VXvXEMA9So947In8773Ey56k6A1WTsZiljAabxZFChBRqOt9nOYczuA==}
+  svelte-inspect-value@0.3.0:
+    resolution: {integrity: sha512-nHv+7+FRePs86sgL2I8jlbSrs8/uJmHJ2uxnMk9tVipWdZYYcmGhsmU+7U8lm/1RAZFS63/xSKdceMDyE09y0A==}
     peerDependencies:
       svelte: ^5.19.0
 
@@ -18189,16 +18189,6 @@ snapshots:
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.4.20(postcss@8.5.1):
-    dependencies:
-      browserslist: 4.24.2
-      caniuse-lite: 1.0.30001676
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.5.1
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
@@ -23343,7 +23333,7 @@ snapshots:
     optionalDependencies:
       svelte: 5.16.6
 
-  svelte-inspect-value@0.2.2(svelte@5.16.6):
+  svelte-inspect-value@0.3.0(svelte@5.16.6):
     dependencies:
       esm-env: 1.2.2
       fast-deep-equal: 3.1.3


### PR DESCRIPTION
closes #127 

- Allow setting extra search path

Will search for `.app` on mac, `.lnk` on windows, `.desktop` on Linux.

![image](https://github.com/user-attachments/assets/71c603f5-34ef-4e45-9f66-e5deb5571d5d)
